### PR TITLE
deps!: update to multiformats 14.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,10 +166,10 @@
   },
   "dependencies": {
     "js-sha3": "^0.9.1",
-    "multiformats": "^13.0.0"
+    "multiformats": "^14.0.0"
   },
   "devDependencies": {
-    "@ipld/dag-cbor": "^9.0.4",
+    "@ipld/dag-cbor": "^10.0.0",
     "aegir": "^48.0.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ import { from } from 'multiformats/hashes/hasher'
 
 /**
  * @param {sha3.Hash} fn
- * @returns {(inp:Uint8Array)=>Uint8Array}
+ * @returns {(inp:Uint8Array)=>Uint8Array<ArrayBuffer>}
  */
 function encoder (fn) {
   return (/** @type {Uint8Array} */ b) => new Uint8Array(fn.array(b))


### PR DESCRIPTION
Updates to latest multiformats version

BREAKING CHANGE: the encoder now returns a `Uint8Array<ArrayBuffer>`